### PR TITLE
Fix JPEG2000 driver installation on Slim builds

### DIFF
--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -41,6 +41,7 @@ RUN set -ex \
        cmake \
        swig \
        ant \
+       pkg-config \
     "\
     && apt-get update && apt-get install -y $buildDeps $deps --no-install-recommends \
     # Compile and install OpenJPEG


### PR DESCRIPTION
## Overview

Previously, slim builds were attempting to compile GDAL `--with-openjpeg`, but the JPEG2000 driver was not available because GDAL depended on the missing [`pkg-config`](https://www.freedesktop.org/wiki/Software/pkg-config/) library to handle some compiler options. Install `pkg-config` as a build dependency on Slim builds in order to properly build GDAL with the OpenJPEG driver.

Closes #4.

## Testing instructions

* Confirm that the Travis build runs successfully
* Pull down the test image that I built locally:

```
$ docker pull quay.io/azavea/openjdk-gdal:2.3-jdk8-slim-openjpeg-fix
```

* Confirm that the test image has the JPEG2000 drivers installed:

```console
$ docker run quay.io/azavea/openjdk-gdal:2.3-jdk8-slim-openjpeg-fix gdalinfo --formats | grep JPEG
  JPEG -raster- (rwv): JPEG JFIF
  JP2OpenJPEG -raster,vector- (rwv): JPEG-2000 driver based on OpenJPEG library
```

* Change into `geotrellis-gdal` and run the tests with the new image to confirm that the JPEG2000 tests run:

```
docker run   \
  -v $(pwd)/build.sbt:/root/build.sbt \
  -v $(pwd)/project:/root/project \
  -v $(pwd)/gdal:/root/gdal \
  -v $(pwd)/src:/root/src \
  -v $(pwd)/sbt:/root/sbt \
  -w /root \
  quay.io/azavea/openjdk-gdal:2.3-jdk8-slim-openjpeg-fix \
  ./sbt "project gdal" test
 ```